### PR TITLE
Small doc fix

### DIFF
--- a/documentation/use_pandocomatic_to_automate_pandoc.md
+++ b/documentation/use_pandocomatic_to_automate_pandoc.md
@@ -220,7 +220,7 @@ the input file, you can **extend** the template in the input file as follows:
 pandocomatic_:
   use-template: research-to-html
   pandoc:
-    to: draft_manuscript.html
+    output: draft_manuscript.html
 ~~~
 
 Running pandocomatic becomes even simpler:


### PR DESCRIPTION
I changes `to: draft_manuscript.html` to `output: draft_manuscript.html` as `to` is for formats not filenames