### PR TITLE
Make sure pandocomatic uses UTF8 irrespective of environment

### DIFF
--- a/lib/pandocomatic/pandocomatic.rb
+++ b/lib/pandocomatic/pandocomatic.rb
@@ -17,7 +17,9 @@
 # with pandocomatic.  If not, see <http://www.gnu.org/licenses/>.
 #++
 module Pandocomatic
-
+  Encoding.default_external = Encoding::UTF_8 #ensure unicode encoding
+  Encoding.default_internal = Encoding::UTF_8
+  
   require 'paru'
 
   require_relative './error/pandocomatic_error.rb'


### PR DESCRIPTION
See #20 — I managed to track down a fairly subtle bug, whereby if Ruby is running in an environment where ENV['LANG']==nil then `Encoding.default_external==US-ASCII`, and that causes UTF8 files to fail. Normally I think Ruby default_external is always UTF8, certainly when I run from my command-line it is. So the fix is to ensure pandocomatic is running in UTF8 mode.