### PR TITLE
switch to use hyphens to pass to paru, more consistent with pandoc.

### DIFF
--- a/lib/pandocomatic/command/convert_file_command.rb
+++ b/lib/pandocomatic/command/convert_file_command.rb
@@ -164,9 +164,10 @@ module Pandocomatic
     def pandoc(input, options, src_dir)
       converter = Paru::Pandoc.new
       options.each do |option, value|
-        # Pandoc multi-word options can have the multiple words separated by
-        # both underscore (_) and dash (-).
-        option= option.gsub "-", "_"
+        # Pandocomatic multi-word options can have the multiple words separated by
+        # both underscore (_) and dash (-); but Pandoc uses — so standardise 
+        # to use it.
+        option= option.gsub "_", "-"
 
         if PANDOC_OPTIONS_WITH_PATH.include? option
           if value.is_a? Array


### PR DESCRIPTION
See https://github.com/htdebeer/paru/pull/21 — pandocomatic is currently broken if you try to use certain options with Pandoc 2. Standardise to use hyphens as that is what pandoc uses for its options.