### PR TITLE
Add  command-line option `--template` (#122)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 documentation/api-doc
 .yardoc
 
-hello_world.html
+hello_world.*
 pandocomatic.log
 
 # Artifacts from running rake in docker 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,10 @@ Version](https://badge.fury.io/rb/pandocomatic.svg)](https://badge.fury.io/rb/pa
 
 # Pandocomatic—Automate the use of pandoc
 
-Pandocomatic automates the use of [pandoc](https://pandoc.org/). With
-pandocomatic you can express common patterns of using pandoc for
-generating your documents. Applied to a directory, pandocomatic acts as
-a static site generator. For example, this manual is generated with
-pandocomatic!
+Pandocomatic automates using [pandoc](https://pandoc.org/). With
+pandocomatic you express common patterns of using pandoc for generating
+your documents. Applied to a directory, pandocomatic acts as a static
+site generator. For example, I generated this manual with pandocomatic!
 
 Pandocomatic is [free
 software](https://www.gnu.org/philosophy/free-sw.en.html); pandocomatic
@@ -15,11 +14,10 @@ is released under the
 [GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html). You will find the
 source code of pandocomatic in its
 [repository](https://github.com/htdebeer/pandocomatic) on
-[Github](https://github.com).
+[GitHub](https://github.com).
 
 **Note.** Pandocomatic is build on top of
-[paru](https://github.com/htdebeer/paru), which is a wrapper around
-pandoc.
+[paru](https://github.com/htdebeer/paru), a wrapper around pandoc.
 
 **Note.** As I am a GNU/Linux user, I do not officially support other
 operating systems like Mac OSX or Windows. Fixes and patches for those
@@ -54,17 +52,17 @@ these invocations are quite similar.
 I already wrote the program *do-pandoc.rb* as part of a Ruby wrapper
 around pandoc, [paru](https://heerdebeer.org/Software/markdown/paru/).
 Using *do-pandoc.rb* I can specify the options to pandoc in a metadata
-block in the source file itself. With *do-pandoc.rb* the invocation
-above is simplified to:
+block in the source file itself. With *do-pandoc.rb* you simplify the
+invocation above to:
 
 ``` bash
 do-pandoc.rb source.md
 ```
 
-It saves me from typing out the whole pandoc invocation each time I run
-pandoc on a source file. However, I have still to setup the same options
-to use in each document that I am writing, even though these options do
-not differ that much from document to document.
+It saves me from typing out the pandoc invocation each time I run pandoc
+on a source file. However, I have still to set up the same options to
+use in each document that I am writing, even though these options do not
+differ that much from document to document.
 
 *Pandocomatic* is a tool to re-use these common configurations by
 specifying a so-called *pandocomatic template* in a
@@ -86,10 +84,10 @@ templates:
     postprocessors: []
 ```
 
-In this configuration file a single *pandocomatic template* is being
-defined: *education-research*. This template specifies that the source
-files it is applied to are not being preprocessed. Furthermore, the
-source files are converted with pandoc by invoking
+In this configuration file I define a single *pandocomatic template*:
+*education-research*. This template specifies that the source files it
+is applied to are not being preprocessed. Furthermore, the source files
+are converted with pandoc by invoking
 `pandoc --from markdown --to html --standalone --csl apa.csl --toc --bibliography /path/to/bibliography.bib --mathjax`.
 Finally, the template specifies that pandoc’s output is not being
 postprocessed.
@@ -125,9 +123,18 @@ process is as easy as adding a `pandoc` property with those options to
 the `pandocomatic_` metadata property in the source file like I did with
 the `output` property in the example above.
 
-Once I had written a number of related documents this way, it was a
-small step to enable pandocomatic to convert directories as well. Just
-like that, pandocomatic can be used as a *static site generator*!
+Alternatively, you can use pandocomatic’s `--template` command-line
+option and skip the `pandocomatic_` metadata block in your source file
+or use pandocomatic with non-markdown source files. In this example, run
+pandocomatic:
+
+``` bash
+pandocomatic -i on_teaching_maths.md --template education-research
+```
+
+Once I had written several related documents this way, it was a small
+step to enable pandocomatic to convert directories as well. Just like
+that, pandocomatic can be used as a *static site generator*!
 
 Pandocomatic is [free
 software](https://www.gnu.org/philosophy/free-sw.en.html); pandocomatic
@@ -154,14 +161,14 @@ installing pandoc.
 
 ### Docker
 
-You can also build and install the latest version yourself by running
-the following commands:
+Alternatively, you can also build and install the latest version
+yourself by running the following commands:
 
 ``` bash
 cd /directory/you/downloaded/the/gem/to
 docker image build --tag pandocomatic:dev .
 docker container run --rm -it --volume $(pwd):/home/pandocomatic-user pandocomatic:dev bundle exec rake build
-gem install pkg/pandocomatic-2.1.0.gem
+gem install pkg/pandocomatic-2.2.0.gem
 ```
 
 You only have to do the second step one time. Once you’ve created a
@@ -169,7 +176,7 @@ docker image, you can reuse it as is until `Dockerfile` changes.
 
 ### MacOS: Brew
 
-Alternatively, MacOS users can install pandocomatic via
+Finally, macOS users can install pandocomatic via
 [homebrew](https://formulae.brew.sh/formula/pandocomatic):
 
 ``` bash

--- a/documentation/convert_a_document.md
+++ b/documentation/convert_a_document.md
@@ -1,9 +1,9 @@
 ## Converting a single document
 
 Pandocomatic allows you to put [pandoc command-line
-options](http://pandoc.org/MANUAL.html) in the document to be converted
+options](https://pandoc.org/MANUAL.html) in the document to be converted
 itself. Instead of a complex pandoc command-line invocation, pandocomatic
-allows you to convert your markdown document `hello_world.md` with just:
+allows you to convert your Markdown document `hello_world.md` with just:
 
 ``` {.bash}
 pandocomatic hello_world.md
@@ -16,7 +16,7 @@ converted according to that **pandocomatic template**. For more information
 about *pandocomatic template*s, see the [chapter about
 templates](#pandocomatic-templates) later in this manual.
 
-For example, if `hello_world.md` contains the following pandoc markdown text:
+For example, if `hello_world.md` contains the following pandoc Markdown text:
 
 ```{.pandoc}
 ::paru::insert ../example/manual/hello_world.md
@@ -45,7 +45,7 @@ pandoc:
 Besides the `pandoc` property to configure the pandoc conversion,
 *pandocomatic templates* can also contain a list of **preprocessors** and a
 list of **postprocessors**. Preprocessors are run before the document is
-converted with pandoc and postprocessors are run afterwards (see the Figure
+converted with pandoc and postprocessors are run afterward (see the Figure
 below): 
 
 ![How pandocomatic works: a simple

--- a/documentation/convert_a_series_of_documents.md
+++ b/documentation/convert_a_series_of_documents.md
@@ -21,20 +21,36 @@ pandocomatic template* `hello` in the *pandocomatic configuration file*
 ::paru::insert ../example/manual/my-config.yaml
 ```
 
-You use it in a pandoc markdown file by specifying the `use-template` sub
-property in the `pandocomatic_` property. The `hello_world.md` example then
-becomes:
+You use an *external pandocomatic template* in one of two ways:
 
-```{.pandoc}
-::paru::insert ../example/manual/external_hello_world.md
-```
+1. You use it in a pandoc markdown file by specifying the `use-template` sub
+   property in the `pandocomatic_` property. The `hello_world.md` example then
+   becomes:
+
+   ```{.pandoc}
+   ::paru::insert ../example/manual/external_hello_world.md
+   ```
+
+2. You use it via command-line option `--template` or `-t`, which takes the template's
+   name as argument. This way, you don't have to have a `pandocomatic_`
+   configuration in your input file's YAML block. This allows you to use
+   *external pandocomatic templates* with any input format. After all, only pandoc's
+   Markdown format supports YAML blocks where you could specify a
+   `pandocomatic_` configuration.
 
 To convert `external_hello_world.md` you need to tell pandocomatic where to
 find the *external pandocomatic template* via the `--config` command-line
-option. For example, to convert `external_hello_world.md` to `out.html`, use:
+option. For example, to convert `external_hello_world.md` to `out.html` via
+the first way, use:
 
 ```{.bash}
 pandocomatic -d my_data_dir --config my-config.yaml -i external_hello_world.md -o out.html
+```
+
+Or, using the second way:
+
+```{.bash}
+pandocomatic -d my_data_dir --config my-config.yaml -i hello_world.md -t hello -o out.html
 ```
 
 ### Customizing external templates with an internal template
@@ -72,6 +88,10 @@ Lists and properties in *internal pandocomatic templates* are merged with
 *external pandocomatic templates*; simple values, such as strings, numbers, or
 Booleans, are replaced. Besides a template's `pandoc` property you can also
 customize any other property of the template.
+
+**Note** When using command-line option `--template`, pandocomatic will
+ignore any *internal pandocomatic templates* and only apply the template
+specified via the command-line option.
 
 ### Extending templates
 

--- a/documentation/faq.md
+++ b/documentation/faq.md
@@ -24,3 +24,58 @@ option. For example:
 ```{.bash}
 pandocomatic --quiet some-file-to-export.md
 ```
+
+### Something goes wrong! How can I figure out what pandocomatic is doing?
+
+Enable logging to see what steps pandocomatic takes while converting your
+documents. Use command-line options `--log` and `--log-level DEBUG` to 
+tell pandocomatic to log everything. By default `--log` logs to file
+`pandocomatic.log`, but you can supply an alternative log file location.
+
+For example:
+
+```{.bash}
+pandocomatic --log /tmp/my-log.txt --log-level DEBUG examples/hello_world.md
+```
+
+will generate log:
+
+```
+# Logfile created on 2025-11-19 13:06:48 +0100 by logger.rb/v1.7.0
+2025-11-19 13:06:48 INFO : ------------ START ---------------
+2025-11-19 13:06:48 INFO : Running /home/huub/.rbenv/versions/3.5-dev/bin/pandocomatic --log /tmp/my-log.txt --log-level DEBUG example/hello_world.md
+2025-11-19 13:06:48 DEBUG: Validating command-line arguments:
+2025-11-19 13:06:48 DEBUG: ✓  Option '--input' not used:  treat all arguments after last option as input files or directories.
+2025-11-19 13:06:48 DEBUG: ✓  Convert single input file or directory.
+2025-11-19 13:06:48 DEBUG: ✓  Input files and directories exist.
+2025-11-19 13:06:48 DEBUG: Start conversion:
+2025-11-19 13:06:48 INFO : (2) + converting /home/huub/Projects/htdebeer@github.com/pandocomatic/example/hello_world.md 1 time:
+2025-11-19 13:06:48 INFO : (1)   - convert hello_world.md -> hello_world.html
+2025-11-19 13:06:48 DEBUG:   #  Using internal template.
+2025-11-19 13:06:48 DEBUG:   #  Selected template mixed with internal template and pandocomatic metadata gives final template:
+                                  extends: []
+                                  glob: []
+                                  setup: []
+                                  preprocessors: []
+                                  metadata: {}
+                                  pandoc:
+                                    from: markdown
+                                    to: html5
+                                  postprocessors: []
+                                  cleanup: []
+2025-11-19 13:06:48 DEBUG:   →  Reading source file: '/home/huub/Projects/htdebeer@github.com/pandocomatic/example/hello_world.md'
+2025-11-19 13:06:48 DEBUG:      | FileInfoPreprocessor. Adding file information to metadata:
+                                     pandocomatic-fileinfo:
+                                       from: markdown
+                                       to: html5
+                                       path: '/home/huub/Projects/htdebeer@github.com/pandocomatic/example/hello_world.md'
+                                       src_path: '/home/huub/Projects/htdebeer@github.com/pandocomatic/example/hello_world.md'
+                                       created: 2025-04-18
+                                       modified: 2024-05-04
+2025-11-19 13:06:48 DEBUG:      #  Changing directory to '/home/huub/Projects/htdebeer@github.com/pandocomatic/example'
+2025-11-19 13:06:48 DEBUG:      #  Running pandoc
+2025-11-19 13:06:48 DEBUG:      |  pandoc       --from=markdown \
+                                                --to=html5
+2025-11-19 13:06:48 DEBUG:   ←  Writing output to './hello_world.html'.
+2025-11-19 13:06:48 INFO : ------------  END  ---------------
+```

--- a/documentation/install.md
+++ b/documentation/install.md
@@ -15,8 +15,8 @@ information about installing pandoc.
 
 ### Docker
 
-You can also build and install the latest version yourself by running the
-following commands:
+Alternatively, you can also build and install the latest version yourself by
+running the following commands:
 
 ~~~{.bash}
 cd /directory/you/downloaded/the/gem/to
@@ -30,7 +30,7 @@ image, you can reuse it as is until `Dockerfile` changes.
 
 ### MacOS: Brew
 
-Alternatively, MacOS users can install pandocomatic via
+Finally, macOS users can install pandocomatic via
 [homebrew](https://formulae.brew.sh/formula/pandocomatic):
 
 ~~~{.bash}

--- a/documentation/introduction.md
+++ b/documentation/introduction.md
@@ -1,14 +1,14 @@
-Pandocomatic automates the use of [pandoc](https://pandoc.org/).  With
-pandocomatic you can express common patterns of using pandoc for generating
-your documents. Applied to a directory, pandocomatic acts as a static site
-generator. For example, this manual is generated with pandocomatic!
+Pandocomatic automates using [pandoc](https://pandoc.org/). With pandocomatic
+you express common patterns of using pandoc for generating your documents.
+Applied to a directory, pandocomatic acts as a static site generator. For
+example, I generated this manual with pandocomatic!
 
 Pandocomatic is [free
 software](https://www.gnu.org/philosophy/free-sw.en.html); pandocomatic is
-released under the [GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html).  You
+released under the [GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html). You
 will find the source code of pandocomatic in its
 [repository](https://github.com/htdebeer/pandocomatic) on
-[Github](https://github.com).
+[GitHub](https://github.com).
 
 **Note.** Pandocomatic is build on top of
-[paru](https://github.com/htdebeer/paru), which is a wrapper around pandoc.
+[paru](https://github.com/htdebeer/paru), a wrapper around pandoc.

--- a/documentation/pandocomatic_cli.md
+++ b/documentation/pandocomatic_cli.md
@@ -42,7 +42,7 @@ will complain if the input and output types do not match.
 
 `-s, --stdout`
 
-:   Print result of converstion to standard output.
+:   Print result of conversion to standard output.
 
     You cannot combine this option with `--output` or with a directory as
     input.
@@ -59,6 +59,18 @@ will complain if the input and output types do not match.
 
 :   Configure pandocomatic to use `FILE` as its configuration file 
     during the conversion process. Default is `DATA_DIR/pandocomatic.yaml`.
+
+`-t TEMPLATE, --template TEMPLATE`
+
+:   Configure pandocomatic to use `TEMPLATE` when converting input to output. 
+    Any internal pandocomatic template in the input is ignored.
+    
+    You can use this option multiple times, for each template a separate 
+    conversion is run. 
+
+    This command-line option only applies when converting input files; it does
+    not work when converting directories. If given template does not exist, 
+    pandocomatic will print an error.
 
 ### Arguments to change how pandocomatic operates
 

--- a/documentation/why_pandocomatic.md
+++ b/documentation/why_pandocomatic.md
@@ -22,16 +22,16 @@ are quite similar.
 I already wrote the program *do-pandoc.rb* as part of a Ruby wrapper around
 pandoc, [paru](https://heerdebeer.org/Software/markdown/paru/). Using
 *do-pandoc.rb* I can specify the options to pandoc in a metadata block in the
-source file itself. With *do-pandoc.rb* the invocation above is simplified to:
+source file itself. With *do-pandoc.rb* you simplify the invocation above to:
 
 ~~~{.bash}
 do-pandoc.rb source.md
 ~~~
 
-It saves me from typing out the whole pandoc invocation each time I run pandoc
-on a source file. However, I have still to setup the same options to use in
-each document that I am writing, even though these options do not differ that
-much from document to document.
+It saves me from typing out the pandoc invocation each time I run pandoc on a
+source file. However, I have still to set up the same options to use in each
+document that I am writing, even though these options do not differ that much
+from document to document.
 
 *Pandocomatic* is a tool to re-use these common configurations by specifying a
 so-called *pandocomatic template* in a [YAML](https://yaml.org/) configuration
@@ -53,7 +53,7 @@ templates:
     postprocessors: []
 ~~~   
 
-In this configuration file a single *pandocomatic template* is being defined:
+In this configuration file I define a single *pandocomatic template*:
 *education-research*. This template specifies that the source files it is
 applied to are not being preprocessed. Furthermore, the source files are
 converted with pandoc by invoking `pandoc --from markdown --to html
@@ -91,6 +91,15 @@ adding a `pandoc` property with those options to the `pandocomatic_` metadata
 property in the source file like I did with the `output` property in the
 example above. 
 
-Once I had written a number of related documents this way, it was a small step
-to enable pandocomatic to convert directories as well. Just like that,
+Alternatively, you can use pandocomatic's `--template` command-line option and
+skip the `pandocomatic_` metadata block in your source file or use
+pandocomatic with non-markdown source files. In this example, run
+pandocomatic:
+
+~~~{.bash}
+pandocomatic -i on_teaching_maths.md --template education-research
+~~~
+
+Once I had written several related documents this way, it was a small step to
+enable pandocomatic to convert directories as well. Just like that,
 pandocomatic can be used as a *static site generator*!

--- a/example/hello_world.tex
+++ b/example/hello_world.tex
@@ -1,0 +1,1 @@
+\emph{Hello world!}, from \textbf{pandocomatic}.

--- a/example/hello_world.typ
+++ b/example/hello_world.typ
@@ -1,0 +1,1 @@
+#emph[Hello world!], from #strong[pandocomatic].

--- a/example/templates.yaml
+++ b/example/templates.yaml
@@ -1,0 +1,9 @@
+templates:
+  latex:
+    pandoc:
+      from: markdown
+      to: latex
+  typst:
+    pandoc:
+      from: markdown
+      to: typst

--- a/index.md
+++ b/index.md
@@ -13,11 +13,10 @@ title: Pandocomatic
 
 # Introduction
 
-Pandocomatic automates the use of [pandoc](https://pandoc.org/). With
-pandocomatic you can express common patterns of using pandoc for
-generating your documents. Applied to a directory, pandocomatic acts as
-a static site generator. For example, this manual is generated with
-pandocomatic!
+Pandocomatic automates using [pandoc](https://pandoc.org/). With
+pandocomatic you express common patterns of using pandoc for generating
+your documents. Applied to a directory, pandocomatic acts as a static
+site generator. For example, I generated this manual with pandocomatic!
 
 Pandocomatic is [free
 software](https://www.gnu.org/philosophy/free-sw.en.html); pandocomatic
@@ -25,11 +24,10 @@ is released under the
 [GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html). You will find the
 source code of pandocomatic in its
 [repository](https://github.com/htdebeer/pandocomatic) on
-[Github](https://github.com).
+[GitHub](https://github.com).
 
 **Note.** Pandocomatic is build on top of
-[paru](https://github.com/htdebeer/paru), which is a wrapper around
-pandoc.
+[paru](https://github.com/htdebeer/paru), a wrapper around pandoc.
 
 ## Acknowledgements
 
@@ -56,14 +54,14 @@ installing pandoc.
 
 ### Docker
 
-You can also build and install the latest version yourself by running
-the following commands:
+Alternatively, you can also build and install the latest version
+yourself by running the following commands:
 
 ``` bash
 cd /directory/you/downloaded/the/gem/to
 docker image build --tag pandocomatic:dev .
 docker container run --rm -it --volume $(pwd):/home/pandocomatic-user pandocomatic:dev bundle exec rake build
-gem install pkg/pandocomatic-2.1.0.gem
+gem install pkg/pandocomatic-2.2.0.gem
 ```
 
 You only have to do the second step one time. Once you've created a
@@ -71,7 +69,7 @@ docker image, you can reuse it as is until `Dockerfile` changes.
 
 ### MacOS: Brew
 
-Alternatively, MacOS users can install pandocomatic via
+Finally, macOS users can install pandocomatic via
 [homebrew](https://formulae.brew.sh/formula/pandocomatic):
 
 ``` bash
@@ -103,17 +101,17 @@ these invocations are quite similar.
 I already wrote the program *do-pandoc.rb* as part of a Ruby wrapper
 around pandoc, [paru](https://heerdebeer.org/Software/markdown/paru/).
 Using *do-pandoc.rb* I can specify the options to pandoc in a metadata
-block in the source file itself. With *do-pandoc.rb* the invocation
-above is simplified to:
+block in the source file itself. With *do-pandoc.rb* you simplify the
+invocation above to:
 
 ``` bash
 do-pandoc.rb source.md
 ```
 
-It saves me from typing out the whole pandoc invocation each time I run
-pandoc on a source file. However, I have still to setup the same options
-to use in each document that I am writing, even though these options do
-not differ that much from document to document.
+It saves me from typing out the pandoc invocation each time I run pandoc
+on a source file. However, I have still to set up the same options to
+use in each document that I am writing, even though these options do not
+differ that much from document to document.
 
 *Pandocomatic* is a tool to re-use these common configurations by
 specifying a so-called *pandocomatic template* in a
@@ -135,10 +133,10 @@ templates:
     postprocessors: []
 ```
 
-In this configuration file a single *pandocomatic template* is being
-defined: *education-research*. This template specifies that the source
-files it is applied to are not being preprocessed. Furthermore, the
-source files are converted with pandoc by invoking
+In this configuration file I define a single *pandocomatic template*:
+*education-research*. This template specifies that the source files it
+is applied to are not being preprocessed. Furthermore, the source files
+are converted with pandoc by invoking
 `pandoc --from markdown --to html --standalone --csl apa.csl --toc --bibliography /path/to/bibliography.bib --mathjax`.
 Finally, the template specifies that pandoc's output is not being
 postprocessed.
@@ -174,9 +172,18 @@ process is as easy as adding a `pandoc` property with those options to
 the `pandocomatic_` metadata property in the source file like I did with
 the `output` property in the example above.
 
-Once I had written a number of related documents this way, it was a
-small step to enable pandocomatic to convert directories as well. Just
-like that, pandocomatic can be used as a *static site generator*!
+Alternatively, you can use pandocomatic's `--template` command-line
+option and skip the `pandocomatic_` metadata block in your source file
+or use pandocomatic with non-markdown source files. In this example, run
+pandocomatic:
+
+``` bash
+pandocomatic -i on_teaching_maths.md --template education-research
+```
+
+Once I had written several related documents this way, it was a small
+step to enable pandocomatic to convert directories as well. Just like
+that, pandocomatic can be used as a *static site generator*!
 
 ------------------------------------------------------------------------
 
@@ -185,9 +192,9 @@ like that, pandocomatic can be used as a *static site generator*!
 ## Converting a single document
 
 Pandocomatic allows you to put [pandoc command-line
-options](http://pandoc.org/MANUAL.html) in the document to be converted
+options](https://pandoc.org/MANUAL.html) in the document to be converted
 itself. Instead of a complex pandoc command-line invocation,
-pandocomatic allows you to convert your markdown document
+pandocomatic allows you to convert your Markdown document
 `hello_world.md` with just:
 
 ``` bash
@@ -201,7 +208,7 @@ and the file is converted according to that **pandocomatic template**.
 For more information about *pandocomatic template*s, see the [chapter
 about templates](#pandocomatic-templates) later in this manual.
 
-For example, if `hello_world.md` contains the following pandoc markdown
+For example, if `hello_world.md` contains the following pandoc Markdown
 text:
 
 ``` pandoc
@@ -239,7 +246,7 @@ pandoc:
 Besides the `pandoc` property to configure the pandoc conversion,
 *pandocomatic templates* can also contain a list of **preprocessors**
 and a list of **postprocessors**. Preprocessors are run before the
-document is converted with pandoc and postprocessors are run afterwards
+document is converted with pandoc and postprocessors are run afterward
 (see the Figure below):
 
 ![How pandocomatic works: a simple
@@ -332,27 +339,42 @@ configuration file* `my-config.yaml` as follows:
              - ./tidy.sh
 ```
 
-You use it in a pandoc markdown file by specifying the `use-template`
-sub property in the `pandocomatic_` property. The `hello_world.md`
-example then becomes:
+You use an *external pandocomatic template* in one of two ways:
 
-``` pandoc
-  ---
-  title: My second pandocomatic-converted document
-  pandocomatic_:
-      use-template: hello
-  ...
-  
-  Hello *World*!
-```
+1.  You use it in a pandoc markdown file by specifying the
+    `use-template` sub property in the `pandocomatic_` property. The
+    `hello_world.md` example then becomes:
+
+    ``` pandoc
+      ---
+      title: My second pandocomatic-converted document
+      pandocomatic_:
+          use-template: hello
+      ...
+      
+      Hello *World*!
+    ```
+
+2.  You use it via command-line option `--template` or `-t`, which takes
+    the template's name as argument. This way, you don't have to have a
+    `pandocomatic_` configuration in your input file's YAML block. This
+    allows you to use *external pandocomatic templates* with any input
+    format. After all, only pandoc's Markdown format supports YAML
+    blocks where you could specify a `pandocomatic_` configuration.
 
 To convert `external_hello_world.md` you need to tell pandocomatic where
 to find the *external pandocomatic template* via the `--config`
 command-line option. For example, to convert `external_hello_world.md`
-to `out.html`, use:
+to `out.html` via the first way, use:
 
 ``` bash
 pandocomatic -d my_data_dir --config my-config.yaml -i external_hello_world.md -o out.html
+```
+
+Or, using the second way:
+
+``` bash
+pandocomatic -d my_data_dir --config my-config.yaml -i hello_world.md -t hello -o out.html
 ```
 
 ### Customizing external templates with an internal template
@@ -391,6 +413,10 @@ Lists and properties in *internal pandocomatic templates* are merged
 with *external pandocomatic templates*; simple values, such as strings,
 numbers, or Booleans, are replaced. Besides a template's `pandoc`
 property you can also customize any other property of the template.
+
+**Note** When using command-line option `--template`, pandocomatic will
+ignore any *internal pandocomatic templates* and only apply the template
+specified via the command-line option.
 
 ### Extending templates
 
@@ -551,7 +577,7 @@ Pandocomatic will complain if the input and output types do not match.
 
 `-s, --stdout`
 
-:   Print result of converstion to standard output.
+:   Print result of conversion to standard output.
 
     You cannot combine this option with `--output` or with a directory
     as input.
@@ -569,6 +595,18 @@ Pandocomatic will complain if the input and output types do not match.
 :   Configure pandocomatic to use `FILE` as its configuration file
     during the conversion process. Default is
     `DATA_DIR/pandocomatic.yaml`.
+
+`-t TEMPLATE, --template TEMPLATE`
+
+:   Configure pandocomatic to use `TEMPLATE` when converting input to
+    output. Any internal pandocomatic template in the input is ignored.
+
+    You can use this option multiple times, for each template a separate
+    conversion is run.
+
+    This command-line option only applies when converting input files;
+    it does not work when converting directories. If given template does
+    not exist, pandocomatic will print an error.
 
 ### Arguments to change how pandocomatic operates
 
@@ -1486,6 +1524,59 @@ command-line option. For example:
 ``` bash
 pandocomatic --quiet some-file-to-export.md
 ```
+
+### Something goes wrong! How can I figure out what pandocomatic is doing?
+
+Enable logging to see what steps pandocomatic takes while converting
+your documents. Use command-line options `--log` and `--log-level DEBUG`
+to tell pandocomatic to log everything. By default `--log` logs to file
+`pandocomatic.log`, but you can supply an alternative log file location.
+
+For example:
+
+``` bash
+pandocomatic --log /tmp/my-log.txt --log-level DEBUG examples/hello_world.md
+```
+
+will generate log:
+
+    # Logfile created on 2025-11-19 13:06:48 +0100 by logger.rb/v1.7.0
+    2025-11-19 13:06:48 INFO : ------------ START ---------------
+    2025-11-19 13:06:48 INFO : Running /home/huub/.rbenv/versions/3.5-dev/bin/pandocomatic --log /tmp/my-log.txt --log-level DEBUG example/hello_world.md
+    2025-11-19 13:06:48 DEBUG: Validating command-line arguments:
+    2025-11-19 13:06:48 DEBUG: ✓  Option '--input' not used:  treat all arguments after last option as input files or directories.
+    2025-11-19 13:06:48 DEBUG: ✓  Convert single input file or directory.
+    2025-11-19 13:06:48 DEBUG: ✓  Input files and directories exist.
+    2025-11-19 13:06:48 DEBUG: Start conversion:
+    2025-11-19 13:06:48 INFO : (2) + converting /home/huub/Projects/htdebeer@github.com/pandocomatic/example/hello_world.md 1 time:
+    2025-11-19 13:06:48 INFO : (1)   - convert hello_world.md -> hello_world.html
+    2025-11-19 13:06:48 DEBUG:   #  Using internal template.
+    2025-11-19 13:06:48 DEBUG:   #  Selected template mixed with internal template and pandocomatic metadata gives final template:
+                                      extends: []
+                                      glob: []
+                                      setup: []
+                                      preprocessors: []
+                                      metadata: {}
+                                      pandoc:
+                                        from: markdown
+                                        to: html5
+                                      postprocessors: []
+                                      cleanup: []
+    2025-11-19 13:06:48 DEBUG:   →  Reading source file: '/home/huub/Projects/htdebeer@github.com/pandocomatic/example/hello_world.md'
+    2025-11-19 13:06:48 DEBUG:      | FileInfoPreprocessor. Adding file information to metadata:
+                                         pandocomatic-fileinfo:
+                                           from: markdown
+                                           to: html5
+                                           path: '/home/huub/Projects/htdebeer@github.com/pandocomatic/example/hello_world.md'
+                                           src_path: '/home/huub/Projects/htdebeer@github.com/pandocomatic/example/hello_world.md'
+                                           created: 2025-04-18
+                                           modified: 2024-05-04
+    2025-11-19 13:06:48 DEBUG:      #  Changing directory to '/home/huub/Projects/htdebeer@github.com/pandocomatic/example'
+    2025-11-19 13:06:48 DEBUG:      #  Running pandoc
+    2025-11-19 13:06:48 DEBUG:      |  pandoc       --from=markdown \
+                                                    --to=html5
+    2025-11-19 13:06:48 DEBUG:   ←  Writing output to './hello_world.html'.
+    2025-11-19 13:06:48 INFO : ------------  END  ---------------
 
 ## Glossary
 

--- a/lib/pandocomatic/cli.rb
+++ b/lib/pandocomatic/cli.rb
@@ -24,6 +24,8 @@ module Pandocomatic
   require_relative 'error/cli_error'
   require_relative 'configuration'
 
+  # rubocop:disable Metrics
+
   ##
   # Command line options parser for pandocomatic using optimist.
   #
@@ -48,8 +50,6 @@ module Pandocomatic
         raise CLIError.new(:problematic_invocation, e, args)
       end
     end
-
-    # rubocop:disable Metrics
 
     # Parse pandocomatic's global options.
     #

--- a/lib/pandocomatic/cli.rb
+++ b/lib/pandocomatic/cli.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #--
-# Copyright 2017-2024, Huub de Beer <huub@heerdebeer.org>
+# Copyright 2017-2025, Huub de Beer <huub@heerdebeer.org>
 #
 # This file is part of pandocomatic.
 #
@@ -70,6 +70,7 @@ module Pandocomatic
         opt :data_dir, 'Data dir', short: '-d', type: String
         opt :config, 'Configuration file', short: '-c', type: String
         opt :root_path, 'Root path', short: '-r', type: String
+        opt :template, 'Template to use for conversion', short: '-t', type: String, multi: true
 
         # What to convert and where to put it
         opt :output, 'Output', short: '-o', type: String
@@ -106,7 +107,7 @@ module Pandocomatic
 
         # if no input option is specified, all items following the last option
         # are treated as input files.
-        if !(options[:input_given])
+        if !options[:input_given]
           Pandocomatic::LOG.debug '✓  Option \'--input\' not used:  ' \
                                   'treat all arguments after last option as input files or directories.'
           options[:input] = args
@@ -143,11 +144,29 @@ module Pandocomatic
         Pandocomatic::LOG.debug '✓  Input files and directories exist.'
 
         # You cannot use the --stdout option while converting directories
-        if options[:stdout_given] && File.directory?(input.first)
+        if convert_directory?(input) && options[:stdout_given]
           options[:stdout] = false
           raise CLIError, :cannot_use_stdout_with_directory
         end
         Pandocomatic::LOG.debug '✓  Write output to STDOUT.' if options[:stdout_given]
+
+        # You cannot use the --template option while converting directories
+        if convert_directory?(input) && options[:template_given]
+          options[:template] = nil
+          raise CLIError, :cannot_use_template_with_directory
+        end
+
+        # Postponing checking for existence of template until configuration
+        # hierarchy has been loaded.
+        if options[:template_given]
+          templates = options[:template]
+          duplicates = templates.select { |t| templates.count(t) > 1 }
+
+          options[:template] = templates.uniq
+
+          Pandocomatic::LOG.debug "✓  Use templates '#{options[:template]}' for conversion."
+          Pandocomatic::LOG.warn " !  Ignoring duplicate templates: #{duplicates}." unless duplicates.empty?
+        end
 
         if options[:output_given]
           # You cannot use --stdout with --output
@@ -224,7 +243,7 @@ module Pandocomatic
     # rubocop:enable Metrics
 
     private_class_method def self.options_need_to_be_validated?(options)
-      !(options[:version_given]) and !(options[:help_given])
+      !options[:version_given] and !options[:help_given]
     end
 
     #--
@@ -266,6 +285,10 @@ module Pandocomatic
 
       raise CLIError.new(:output_is_not_a_file, nil, input) if File.file? input
       raise CLIError.new(:output_is_not_a_directory, nil, input) if File.directory? input
+    end
+
+    private_class_method def self.convert_directory?(input)
+      File.directory? input.first
     end
   end
 end

--- a/lib/pandocomatic/command/convert_file_command.rb
+++ b/lib/pandocomatic/command/convert_file_command.rb
@@ -127,9 +127,10 @@ module Pandocomatic
       str
     end
 
-    private
-
+    # Name of the anonymous inner template.
     INTERNAL_TEMPLATE = 'internal template'
+
+    private
 
     def convert_file
       pandoc_options = @metadata.pandoc_options || {}
@@ -164,18 +165,16 @@ module Pandocomatic
              '"--enable pandoc-verbose".'
       end
 
+      template_log = Pandocomatic::LOG.indent(YAML.dump(template.to_h).sub('---', ''), 34)
+
       if @metadata.pandocomatic?
         template.merge! Template.new(INTERNAL_TEMPLATE, @metadata.pandocomatic)
 
         Pandocomatic::LOG.debug '  #  Selected template mixed with internal template and pandocomatic metadata ' \
-                                "gives final template:#{Pandocomatic::LOG.indent(YAML.dump(template.to_h).sub('---', ''),
-                                                                                 34)}"
+                                "gives final template:#{template_log}"
       else
-        Pandocomatic::LOG.debug '  #  Selected template' \
-                                ":#{Pandocomatic::LOG.indent(YAML.dump(template.to_h).sub('---', ''),
-                                                             34)}"
+        Pandocomatic::LOG.debug "  #  Selected template:#{template_log}"
       end
-
 
       # Write out the results of the conversion process to file.
       @dst = @metadata.pandoc_options['output'] if @dst.to_s.empty? && @metadata.pandoc_options.key?('output')

--- a/lib/pandocomatic/command/convert_file_command.rb
+++ b/lib/pandocomatic/command/convert_file_command.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #--
-# Copyright 2017-2024, Huub de Beer <Huub@heerdebeer.org>
+# Copyright 2017-2025, Huub de Beer <Huub@heerdebeer.org>
 #
 # This file is part of pandocomatic.
 #
@@ -164,11 +164,18 @@ module Pandocomatic
              '"--enable pandoc-verbose".'
       end
 
-      template.merge! Template.new(INTERNAL_TEMPLATE, @metadata.pandocomatic) if @metadata.pandocomatic?
+      if @metadata.pandocomatic?
+        template.merge! Template.new(INTERNAL_TEMPLATE, @metadata.pandocomatic)
 
-      Pandocomatic::LOG.debug '  #  Selected template mixed with internal template and pandocomatic metadata ' \
-                              "gives final template:#{Pandocomatic::LOG.indent(YAML.dump(template.to_h).sub('---', ''),
-                                                                               34)}"
+        Pandocomatic::LOG.debug '  #  Selected template mixed with internal template and pandocomatic metadata ' \
+                                "gives final template:#{Pandocomatic::LOG.indent(YAML.dump(template.to_h).sub('---', ''),
+                                                                                 34)}"
+      else
+        Pandocomatic::LOG.debug '  #  Selected template' \
+                                ":#{Pandocomatic::LOG.indent(YAML.dump(template.to_h).sub('---', ''),
+                                                             34)}"
+      end
+
 
       # Write out the results of the conversion process to file.
       @dst = @metadata.pandoc_options['output'] if @dst.to_s.empty? && @metadata.pandoc_options.key?('output')

--- a/lib/pandocomatic/command/convert_file_multiple_command.rb
+++ b/lib/pandocomatic/command/convert_file_multiple_command.rb
@@ -110,7 +110,7 @@ module Pandocomatic
 
       description = CommandPrinter.new(self)
       Pandocomatic::LOG.info description
-      
+
       run if !dry_run? && runnable?
 
       @subcommands.each(&:execute)

--- a/lib/pandocomatic/command/convert_file_multiple_command.rb
+++ b/lib/pandocomatic/command/convert_file_multiple_command.rb
@@ -49,11 +49,12 @@ module Pandocomatic
       @config = config
       @src = src
 
-
       subcommands = []
 
       if @config.use_templates?
         # Command-line specified template overrides all internal templates
+        Pandocomatic::LOG.info 'Ignoring any internal pandocomatic configuration from input\'s YAML blocks'
+
         @config.selected_templates.each do |template|
           subcommands.push ConvertFileCommand.new(@config, @src, dst, template)
         end
@@ -109,7 +110,8 @@ module Pandocomatic
 
       description = CommandPrinter.new(self)
       Pandocomatic::LOG.info description
-      description.print unless quiet? || (@subcommands.size == 1)
+      0p3n
+      
       run if !dry_run? && runnable?
 
       @subcommands.each(&:execute)

--- a/lib/pandocomatic/command/convert_file_multiple_command.rb
+++ b/lib/pandocomatic/command/convert_file_multiple_command.rb
@@ -110,7 +110,6 @@ module Pandocomatic
 
       description = CommandPrinter.new(self)
       Pandocomatic::LOG.info description
-      0p3n
       
       run if !dry_run? && runnable?
 

--- a/lib/pandocomatic/command/convert_file_multiple_command.rb
+++ b/lib/pandocomatic/command/convert_file_multiple_command.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #--
-# Copyright 2017—2024 Huub de Beer <Huub@heerdebeer.org>
+# Copyright 2017—2025 Huub de Beer <Huub@heerdebeer.org>
 #
 # This file is part of pandocomatic.
 #
@@ -49,30 +49,38 @@ module Pandocomatic
       @config = config
       @src = src
 
-      metadata = @config.get_metadata @src
 
       subcommands = []
 
-      if metadata&.template?
-        # There are templates in this document's metadata, try to use
-        # those.
-        metadata.templates.each do |template_name|
-          unless template_name.empty? || config.template?(template_name)
-            raise ConfigurationError.new(:no_such_template, nil,
-                                         template_name)
-          end
-
-          subcommands.push ConvertFileCommand.new(@config, @src, dst, template_name)
+      if @config.use_templates?
+        # Command-line specified template overrides all internal templates
+        @config.selected_templates.each do |template|
+          subcommands.push ConvertFileCommand.new(@config, @src, dst, template)
         end
       else
-        # Try to match any global templates using the glob patterns
-        global_templates = @config.determine_templates(@src)
+        metadata = @config.get_metadata @src
 
-        if global_templates.empty?
-          subcommands.push ConvertFileCommand.new(@config, @src, dst)
-        else
-          global_templates.each do |template_name|
+        if metadata&.template?
+          # There are templates in this document's metadata, try to use
+          # those.
+          metadata.templates.each do |template_name|
+            unless template_name.empty? || config.template?(template_name)
+              raise ConfigurationError.new(:no_such_template, nil,
+                                           template_name)
+            end
+
             subcommands.push ConvertFileCommand.new(@config, @src, dst, template_name)
+          end
+        else
+          # Try to match any global templates using the glob patterns
+          global_templates = @config.determine_templates(@src)
+
+          if global_templates.empty?
+            subcommands.push ConvertFileCommand.new(@config, @src, dst)
+          else
+            global_templates.each do |template_name|
+              subcommands.push ConvertFileCommand.new(@config, @src, dst, template_name)
+            end
           end
         end
       end

--- a/lib/pandocomatic/error/cli_error.rb
+++ b/lib/pandocomatic/error/cli_error.rb
@@ -2,7 +2,6 @@
 
 #--
 # Copyright 2017-2025, Huub de Beer <Huub@heerdebeer.org>
-#
 # This file is part of pandocomatic.
 #
 # Pandocomatic is free software: you can redistribute it and/or modify

--- a/lib/pandocomatic/error/cli_error.rb
+++ b/lib/pandocomatic/error/cli_error.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #--
-# Copyright 2017, Huub de Beer <Huub@heerdebeer.org>
+# Copyright 2017-2025, Huub de Beer <Huub@heerdebeer.org>
 #
 # This file is part of pandocomatic.
 #
@@ -40,6 +40,7 @@ module Pandocomatic
     # :output_it_not_writable,
 
     # :cannot_use_stdout_with_directory
+    # :cannot_use_template_with_directory
     # :cannot_use_both_output_and_stdout
 
     # :unknown_option,

--- a/lib/pandocomatic/error/configuration_error.rb
+++ b/lib/pandocomatic/error/configuration_error.rb
@@ -38,5 +38,6 @@ module Pandocomatic
     # :unable_to_load_config_file
 
     # :no_such_template
+    # :templates_do_not_exist
   end
 end

--- a/lib/pandocomatic/pandoc_metadata.rb
+++ b/lib/pandocomatic/pandoc_metadata.rb
@@ -88,8 +88,12 @@ module Pandocomatic
         PandocMetadata.new
       else
         metadata = PandocMetadata.new PandocomaticYAML.load(yaml, path), unique: pandocomatic_blocks <= 1
-        metadata.delete('pandocomatic') if ignore_pandocomatic
-        metadata.delete('pandocomatic_') if ignore_pandocomatic
+
+        if ignore_pandocomatic
+          metadata.delete('pandocomatic')
+          metadata.delete('pandocomatic_')
+        end
+
         metadata
       end
     end

--- a/lib/pandocomatic/pandocomatic.rb
+++ b/lib/pandocomatic/pandocomatic.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #--
-# Copyright 2014—2024, Huub de Beer <huub@heerdebeer.org>
+# Copyright 2014—2025, Huub de Beer <huub@heerdebeer.org>
 #
 # This file is part of pandocomatic.
 #
@@ -219,6 +219,7 @@ module Pandocomatic
       # An unexpected error has occurred; break off the program drastically
       # for now. This is likely a bug: ask the user to report it.
       UnknownErrorPrinter.new(e).print
+      LOG.error e.backtrace.join("\n")
       exit ERROR_STATUS + 2
     ensure
       configuration&.clean_up!

--- a/lib/pandocomatic/printer/views/cli_error.txt
+++ b/lib/pandocomatic/printer/views/cli_error.txt
@@ -14,6 +14,8 @@ See `pandocomatic --help` which options are allowed.
 <%=@error.error.message%>.
 <% when :cannot_use_stdout_with_directory %>
 Using `--stdout/-s` with an input directory is not allowed.
+<% when :cannot_use_template_with_directory %>
+Using `--template/-t` with an input directory is not allowed.
 <% when :cannot_use_both_output_and_stdout %>
 Using both `--output/-o` and `--stdout/-s` is not allowed.
 Use eiter a specific output file or directory, or standard out, not both.

--- a/lib/pandocomatic/printer/views/help.txt
+++ b/lib/pandocomatic/printer/views/help.txt
@@ -97,6 +97,19 @@ OPTIONS
                   respectively. In a file, the property 'use-template' tells
                   pandocomatic which template to use.
 
+  -t TEMPLATE, --template TEMPLATE
+                  Use given TEMPLATE for conversion. TEMPLATE should be
+                  defined in pandocomatic's configuration hierarchy. TEMPLATE
+                  will override any internal template. More so pandocomatic 
+                  configuration in YAML block will be ignored.
+
+                  Only allowed when converting files; option not allowed when
+                  converting directories.
+
+                  You can use this option multiple times. For each given 
+                  TEMPLATE a separate conversion is run. Duplicate TEMPLATEs
+                  are ignored.
+
   -m, --modified-only
         
                   Only convert files that have been modified. Only source files
@@ -179,7 +192,7 @@ AUTHOR
 
 LICENSE
 
-  Copyright 2014—2024 Huub de Beer <huub@heerdebeer.org>
+  Copyright 2014—2025 Huub de Beer <huub@heerdebeer.org>
 
   Pandocomatic is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by the

--- a/lib/pandocomatic/version.rb
+++ b/lib/pandocomatic/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #--
-# Copyright 2023—2024 Huub de Beer <Huub@heerdebeer.org>
+# Copyright 2023—2025 Huub de Beer <Huub@heerdebeer.org>
 #
 # This file is part of pandocomatic.
 #
@@ -20,5 +20,5 @@
 #++
 module Pandocomatic
   # Pandocomatic's current version.
-  VERSION = [2, 1, 0].freeze
+  VERSION = [2, 2, 0].freeze
 end

--- a/test/files/templates.yaml
+++ b/test/files/templates.yaml
@@ -1,0 +1,11 @@
+templates:
+  a:
+    metadata:
+      variable: a
+  b:
+    metadata:
+      variable: b
+  c:
+    metadata:
+      variable: c
+

--- a/test/unit/cli.rb
+++ b/test/unit/cli.rb
@@ -181,4 +181,37 @@ class TestPandocomaticCLI < Minitest::Test
 
     assert_equal e.message, 'Multiple input files only'
   end
+
+  def test_template_not_for_directories
+    e = assert_raises Pandocomatic::CLIError do
+      cli('-i test/files/readable_test_dir -t a -c test/files/templates.yaml')
+    end
+
+    assert_equal e.message, 'Cannot use template with directory'
+  end
+
+  def test_template_does_not_exist
+    e = assert_raises Pandocomatic::ConfigurationError do
+      cli('-i test/files/readable_test_file -t a -t d -c test/files/templates.yaml')
+    end
+
+    assert_equal e.message, 'Templates do not exist'
+    assert_equal e.data, ['d']
+  end
+
+  def test_templates
+    # No template given
+    options = cli('-i test/files/readable_test_file -c test/files/templates.yaml')
+    refute options.use_templates?
+
+    # Templates given
+    options = cli('-i test/files/readable_test_file -t a -t b -t c -c test/files/templates.yaml')
+    assert options.use_templates?
+    assert_equal options.selected_templates, %w[a b c]
+
+    # Duplicates are removed
+    options = cli('-i test/files/readable_test_file -t a -t b -t b -c test/files/templates.yaml')
+    assert options.use_templates?
+    assert_equal options.selected_templates, %w[a b]
+  end
 end

--- a/test/unit/pandocomatic.rb
+++ b/test/unit/pandocomatic.rb
@@ -566,4 +566,36 @@ exit"
       assert_files_equal example_output, output
     end
   end
+
+  def test_template_specified_on_command_line
+    Dir.mktmpdir('template') do |dir|
+      # Latex template
+      input = File.join ['example', 'hello_world.md']
+      output = File.join [dir, 'hello_world.tex']
+      config = File.join ['example', 'templates.yaml']
+
+      Pandocomatic::Pandocomatic.run "-i #{input} -o #{output} -c #{config} -t latex"
+
+      latex_output = File.join ['example', 'hello_world.tex']
+
+      assert_files_equal latex_output, output
+    end
+  end
+
+  def test_multiple_templates_specified_on_command_line
+    Dir.mktmpdir('templates') do |dir|
+      # Latex template
+      input = File.join ['example', 'hello_world.md']
+      output = File.join [dir, 'hello_world.tex']
+      config = File.join ['example', 'templates.yaml']
+
+      Pandocomatic::Pandocomatic.run "-i #{input} -c #{config} -o #{output} -t latex -t typst"
+
+      latex_output = File.join ['example', 'hello_world.tex']
+      typst_output = File.join ['example', 'hello_world.typ']
+
+      assert_files_equal latex_output, File.join([dir, 'hello_world.tex'])
+      assert_files_equal typst_output, File.join([dir, 'hello_world.typ'])
+    end
+  end
 end


### PR DESCRIPTION
As requested in #122, I've added a `--template` command-line option to pandocomatic.

You can use the `--template` option multiple times. For each time, a separate conversion with that specific template is run. Duplicate templates are ignored. When templates don't exist, you get an error.

For example:

```bash
pandocomatic \
  --config template_defs.yaml \
  --input my_file.tex \
  --template print \
  --template web
```

will generate two files, one following the "print" template and one following the "web" template assuming both are defined in "template_defs.yaml" or elsewhere in configuration hierarchy.


**TODO:** 

- Update manual and documentation